### PR TITLE
Adding explicit count and error checking due to Terraform issue 17421

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,19 +12,20 @@ Creates the following resources:
 
 ```hcl
 module "my_lambda_function" {
-  source                = "trussworks/terraform-aws-lambda"
-  name                  = "my_app"
-  job_identifier        = "instance_alpha"
-  runtime               = "go1.x"
-  role_policy_arns      = ["${aws_iam_policy.my_app_lambda_policy.arn}"]
-  s3_bucket             = "my_s3_bucket"
-  s3_key                = "my_app/1.0/my_app.zip"
+  source                 = "trussworks/terraform-aws-lambda"
+  name                   = "my_app"
+  job_identifier         = "instance_alpha"
+  runtime                = "go1.x"
+  role_policy_arns_count = 1
+  role_policy_arns       = ["${aws_iam_policy.my_app_lambda_policy.arn}"]
+  s3_bucket              = "my_s3_bucket"
+  s3_key                 = "my_app/1.0/my_app.zip"
 
-  subnet_ids            = ["subnet-0123456789abcdef0"]
-  security_group_ids    = ["sg-0123456789abcdef0"]
+  subnet_ids             = ["subnet-0123456789abcdef0"]
+  security_group_ids     = ["sg-0123456789abcdef0"]
 
-  source_types          = ["events"]
-  source_arns           = ["${aws_cloudwatch_event_rule.trigger.arn}"]
+  source_types           = ["events"]
+  source_arns            = ["${aws_cloudwatch_event_rule.trigger.arn}"]
 
   env_vars {
     VARNAME = "value"
@@ -47,6 +48,7 @@ module "my_lambda_function" {
 | memory\_size | Size in MB of Lambda function memory allocation | string | `"128"` | no |
 | name | Lambda function name | string | n/a | yes |
 | role\_policy\_arns | List of policy ARNs to attach to Lambda role | list | n/a | yes |
+| role\_policy\_arns\_count | Count of policy ARNs to attach to Lambda role | number | n/a | yes |
 | runtime | Lambda runtime type | string | n/a | yes |
 | s3\_bucket | Name of s3 bucket used for Lambda build | string | n/a | yes |
 | s3\_key | Key for s3 object for Lambda function code | string | n/a | yes |

--- a/variables.tf
+++ b/variables.tf
@@ -13,6 +13,12 @@ variable "runtime" {
   type        = "string"
 }
 
+# We need an explicit count because of Terraform issue 17421
+variable "role_policy_arns_count" {
+  description = "Count of policy ARNs to attach to Lambda role"
+  type        = "number"
+}
+
 variable "role_policy_arns" {
   description = "List of policy ARNs to attach to Lambda role"
   type        = "list"


### PR DESCRIPTION
Due to https://github.com/hashicorp/terraform/issues/17421, we need to have the length of the role_policy_arns input explicitly passed as another variable. :/ This adds that, and also a null resource for making sure they are equal.