### PR TITLE
Fix to convert subnet ids and security group ids params to lists

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -147,8 +147,8 @@ resource "aws_lambda_function" "main" {
   tags = "${var.tags}"
 
   vpc_config {
-    subnet_ids         = "${var.subnet_ids}"
-    security_group_ids = "${var.security_group_ids}"
+    subnet_ids         = ["${var.subnet_ids}"]
+    security_group_ids = ["${var.security_group_ids}"]
   }
 }
 


### PR DESCRIPTION
When trying to create a lambda with subnet ids and SG ids, the aws_lambda_function resource errored because it expects lists. This fixes that.