### PR TITLE
Fixing Dependency Issues

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -1,28 +1,28 @@
 variable "name" {
   description = "Lambda function name"
-  type        = "string"
+  type        = string
 }
 
 variable "job_identifier" {
   description = "Identifier for specific instance of Lambda function"
-  type        = "string"
+  type        = string
 }
 
 variable "runtime" {
   description = "Lambda runtime type"
-  type        = "string"
+  type        = string
 }
 
 # Either deploy from a specified bucket
 variable "s3_bucket" {
   description = "Name of s3 bucket used for Lambda build"
-  type        = "string"
+  type        = string
   default     = ""
 }
 
 variable "s3_key" {
   description = "Key for s3 object for Lambda function code"
-  type        = "string"
+  type        = string
   default     = ""
 }
 
@@ -54,71 +54,71 @@ variable "validation_sha" {
 # We need an explicit count because of Terraform issue 17421
 variable "role_policy_arns_count" {
   description = "Count of policy ARNs to attach to Lambda role"
-  type        = "string"
+  type        = string
 }
 
 variable "role_policy_arns" {
   description = "List of policy ARNs to attach to Lambda role"
-  type        = "list"
+  type        = list
 }
 
 
 variable "memory_size" {
   default     = 128
   description = "Size in MB of Lambda function memory allocation"
-  type        = "string"
+  type        = string
 }
 
 variable "timeout" {
   default     = 60
   description = "Timeout in seconds for Lambda function timeout"
-  type        = "string"
+  type        = string
 }
 
 variable "tags" {
   default     = {}
   description = "Map of tags for Lambda function"
-  type        = "map"
+  type        = map
 }
 
 variable "env_vars" {
   default     = {}
   description = "Map of environment variables for Lambda function"
-  type        = "map"
+  type        = map
 }
 
 variable "subnet_ids" {
   default     = []
   description = "List of subnet IDs for Lambda VPC config (leave empty if no VPC)"
-  type        = "list"
+  type        = list
 }
 
 variable "security_group_ids" {
   default     = []
   description = "List of security group IDs for Lambda VPC config (leave empty if no VPC)"
-  type        = "list"
+  type        = list
 }
 
 variable "cloudwatch_logs_retention_days" {
   default     = 30
   description = "Number of days to retain logs in Cloudwatch Logs"
-  type        = "string"
+  type        = string
 }
 
 variable "source_types" {
   default     = []
   description = "List of sources for Lambda triggers; order must match source_arns"
-  type        = "list"
+  type        = list
 }
 
 variable "source_arns" {
   default     = []
   description = "List of arns for Lambda triggers; order must match source_types"
-  type        = "list"
+  type        = list
 }
 
 variable "handler" {
   default     = "main.Main"
   description = "The entrypoint function for the lambda function."
-  type        = "string"
+  type        = string
 }


### PR DESCRIPTION
This PR fixes two dependency related issues. In addition updates the variables file so variables are represented without double quotes.

### Issue 1
This issue is TF trying to create a Lambda before the deployment package was downloaded.  I think this surfaced due to my really slow upload speed. I have `--->` out where TF is trying to create the Lambda before the download script can finish downloading.

```
module.iam_sleuth.aws_cloudwatch_log_group.main: Creation complete after 2s [id=/aws/lambda/iam-sleuth-test]
----> module.iam_sleuth.aws_lambda_function.main_from_gh[0]: Creating...
module.iam_sleuth.aws_iam_role_policy.main: Creation complete after 1s [id=lambda-iam-sleuth-test:lambda-iam-sleuth-test]
aws_iam_role_policy_attachment.basic_execution: Creation complete after 1s [id=iam_sleuth-20201214191327326500000001]
module.iam_sleuth.aws_iam_role_policy_attachment.user_policy_attach[1]: Creation complete after 1s [id=lambda-iam-sleuth-test-20201214191327544000000002]
aws_iam_role_policy_attachment.policy_attachment: Creation complete after 1s [id=iam_sleuth-20201214191327576000000003]
module.iam_sleuth.aws_iam_role_policy_attachment.user_policy_attach[0]: Creation complete after 1s [id=lambda-iam-sleuth-test-20201214191327576200000004]
module.iam_sleuth.null_resource.get_github_release_artifact[0] (local-exec): The downloaded file's sha matched expected sha.
----> module.iam_sleuth.null_resource.get_github_release_artifact[0] (local-exec): Script done
module.iam_sleuth.null_resource.get_github_release_artifact[0]: Creation complete after 4s [id=3513549229859339682]
module.iam_sleuth.aws_lambda_function.main_from_gh[0]: Still creating... [10s elapsed]
module.iam_sleuth.aws_lambda_function.main_from_gh[0]: Still creating... [20s elapsed]
```

### Issue 2
This issue is a missing dependency of the AWS Lambda Permission object. The permission was being applied before the Lambda could be created. The Permission resource was referring to a string variable instead of another resources so TF build a dependency chain. 

The fix was to add such a dependency except the fix is specific to the source (GH or S3) of the deployment. Opted to use two different resources to add such a permission dependency on the related Lambda. There may be a cleaner way to implement said fix than https://github.com/trussworks/terraform-aws-lambda/compare/lh_fix_dep?expand=1#diff-dc46acf24afd63ef8c556b77c126ccc6e578bc87e3aa09a931f33d9bf2532fbbR175.

```
Error: Error adding new Lambda Permission for iam-sleuth-test: ResourceNotFoundException: Function not found: arn:aws:lambda:us-east-2:052474651838:function:iam-sleuth-test
{
  RespMetadata: {
    StatusCode: 404,
    RequestID: "d4b23108-6d26-4d91-b144-250b016d9d60"
  },
  Message_: "Function not found: arn:aws:lambda:us-east-2:052474651838:function:iam-sleuth-test",
  Type: "User"
}
```