### PR TITLE
feat: add GitHub auth support

### DIFF
--- a/.markdownlintrc
+++ b/.markdownlintrc
@@ -3,5 +3,8 @@
   "first-header-h1": false,
   "first-line-h1": false,
   "line_length": false,
-  "no-multiple-blanks": false
+  "no-multiple-blanks": false,
+  "MD033": {
+    "allowed_elements": ["a", "pre", "br"]
+  }
 }

--- a/README.md
+++ b/README.md
@@ -42,51 +42,75 @@ module "my_lambda_function" {
 
 | Name | Version |
 |------|---------|
-| terraform | >= 0.13.0 |
-| aws | >= 3.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| aws | >= 3.0 |
-| null | n/a |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.0 |
+| <a name="provider_null"></a> [null](#provider\_null) | n/a |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_cloudwatch_log_group.main](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_group) | resource |
+| [aws_iam_role.main](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
+| [aws_iam_role_policy.main](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
+| [aws_iam_role_policy_attachment.user_policy_attach](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_lambda_function.main_from_gh](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_function) | resource |
+| [aws_lambda_function.main_from_s3](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_function) | resource |
+| [aws_lambda_permission.allow_source_gh](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_permission) | resource |
+| [aws_lambda_permission.allow_source_s3](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_permission) | resource |
+| [null_resource.get_github_release_artifact](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
+| [null_resource.verify_policy_list_count](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
+| [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
+| [aws_iam_policy_document.assume_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.logs_policy_doc](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_partition.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/partition) | data source |
+| [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| cloudwatch\_logs\_retention\_days | Number of days to retain logs in Cloudwatch Logs | `string` | `30` | no |
-| env\_vars | Map of environment variables for Lambda function | `map` | `{}` | no |
-| github\_filename | Name of the file to get when building url to pull. | `string` | `"deployment.zip"` | no |
-| github\_project | The unique Github project to pull from. Currently, this must be public. Eg. 'trussworks/aws-iam-sleuth' | `string` | `""` | no |
-| github\_release | The release tag to download. | `string` | `""` | no |
-| handler | The entrypoint function for the lambda function. | `string` | `"main.Main"` | no |
-| job\_identifier | Identifier for specific instance of Lambda function | `string` | n/a | yes |
-| memory\_size | Size in MB of Lambda function memory allocation | `string` | `128` | no |
-| name | Lambda function name | `string` | n/a | yes |
-| publish | Whether to publish creation/change as new Lambda Function Version. | `bool` | `false` | no |
-| role\_policy\_arns | List of policy ARNs to attach to Lambda role | `list` | n/a | yes |
-| role\_policy\_arns\_count | Count of policy ARNs to attach to Lambda role | `string` | n/a | yes |
-| runtime | Lambda runtime type | `string` | n/a | yes |
-| s3\_bucket | Name of s3 bucket used for Lambda build | `string` | `""` | no |
-| s3\_key | Key for s3 object for Lambda function code | `string` | `""` | no |
-| security\_group\_ids | List of security group IDs for Lambda VPC config (leave empty if no VPC) | `list` | `[]` | no |
-| source\_arns | List of arns for Lambda triggers; order must match source\_types | `list` | `[]` | no |
-| source\_types | List of sources for Lambda triggers; order must match source\_arns | `list` | `[]` | no |
-| subnet\_ids | List of subnet IDs for Lambda VPC config (leave empty if no VPC) | `list` | `[]` | no |
-| tags | Map of tags for Lambda function | `map` | `{}` | no |
-| timeout | Timeout in seconds for Lambda function timeout | `string` | `60` | no |
-| validation\_sha | SHA to validate the file. | `string` | `""` | no |
+| <a name="input_cloudwatch_logs_retention_days"></a> [cloudwatch\_logs\_retention\_days](#input\_cloudwatch\_logs\_retention\_days) | Number of days to retain logs in Cloudwatch Logs | `string` | `30` | no |
+| <a name="input_env_vars"></a> [env\_vars](#input\_env\_vars) | Map of environment variables for Lambda function | `map(any)` | `{}` | no |
+| <a name="input_github_filename"></a> [github\_filename](#input\_github\_filename) | Name of the file to get when building url to pull. | `string` | `"deployment.zip"` | no |
+| <a name="input_github_project"></a> [github\_project](#input\_github\_project) | The unique Github project to pull from. | `string` | `""` | no |
+| <a name="input_github_release"></a> [github\_release](#input\_github\_release) | The release tag to download. | `string` | `""` | no |
+| <a name="input_github_token"></a> [github\_token](#input\_github\_token) | GitHub Token | `string` | n/a | yes |
+| <a name="input_handler"></a> [handler](#input\_handler) | The entrypoint function for the lambda function. | `string` | `"main.Main"` | no |
+| <a name="input_job_identifier"></a> [job\_identifier](#input\_job\_identifier) | Identifier for specific instance of Lambda function | `string` | n/a | yes |
+| <a name="input_memory_size"></a> [memory\_size](#input\_memory\_size) | Size in MB of Lambda function memory allocation | `string` | `128` | no |
+| <a name="input_name"></a> [name](#input\_name) | Lambda function name | `string` | n/a | yes |
+| <a name="input_publish"></a> [publish](#input\_publish) | Whether to publish creation/change as new Lambda Function Version. | `bool` | `false` | no |
+| <a name="input_role_policy_arns"></a> [role\_policy\_arns](#input\_role\_policy\_arns) | List of policy ARNs to attach to Lambda role | `list(any)` | n/a | yes |
+| <a name="input_role_policy_arns_count"></a> [role\_policy\_arns\_count](#input\_role\_policy\_arns\_count) | Count of policy ARNs to attach to Lambda role | `string` | n/a | yes |
+| <a name="input_runtime"></a> [runtime](#input\_runtime) | Lambda runtime type | `string` | n/a | yes |
+| <a name="input_s3_bucket"></a> [s3\_bucket](#input\_s3\_bucket) | Name of s3 bucket used for Lambda build | `string` | `""` | no |
+| <a name="input_s3_key"></a> [s3\_key](#input\_s3\_key) | Key for s3 object for Lambda function code | `string` | `""` | no |
+| <a name="input_security_group_ids"></a> [security\_group\_ids](#input\_security\_group\_ids) | List of security group IDs for Lambda VPC config (leave empty if no VPC) | `list(any)` | `[]` | no |
+| <a name="input_source_arns"></a> [source\_arns](#input\_source\_arns) | List of arns for Lambda triggers; order must match source\_types | `list(any)` | `[]` | no |
+| <a name="input_source_types"></a> [source\_types](#input\_source\_types) | List of sources for Lambda triggers; order must match source\_arns | `list(any)` | `[]` | no |
+| <a name="input_subnet_ids"></a> [subnet\_ids](#input\_subnet\_ids) | List of subnet IDs for Lambda VPC config (leave empty if no VPC) | `list(any)` | `[]` | no |
+| <a name="input_tags"></a> [tags](#input\_tags) | Map of tags for Lambda function | `map(any)` | `{}` | no |
+| <a name="input_timeout"></a> [timeout](#input\_timeout) | Timeout in seconds for Lambda function timeout | `string` | `60` | no |
+| <a name="input_validation_sha"></a> [validation\_sha](#input\_validation\_sha) | SHA to validate the file. | `string` | `""` | no |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| function\_name | Name of the AWS Lambda function |
-| invoke\_arn | ARN used to invoke Lambda function from API Gateway |
-| lambda\_arn | ARN for the Lambda function |
-
+| <a name="output_function_name"></a> [function\_name](#output\_function\_name) | Name of the AWS Lambda function |
+| <a name="output_invoke_arn"></a> [invoke\_arn](#output\_invoke\_arn) | ARN used to invoke Lambda function from API Gateway |
+| <a name="output_lambda_arn"></a> [lambda\_arn](#output\_lambda\_arn) | ARN for the Lambda function |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 
 ## Terraform Versions

--- a/main.tf
+++ b/main.tf
@@ -6,8 +6,7 @@ locals {
   full_name = "${var.name}-${var.job_identifier}"
 
   # Only use github if project is defined... otherwise default to expecting s3
-  from_github   = var.github_project != "" ? true : false
-  github_dl_url = "https://github.com/${var.github_project}/releases/download/${var.github_release}"
+  from_github = var.github_project != "" ? true : false
 }
 
 # This is the IAM policy for letting lambda assume roles.
@@ -127,7 +126,7 @@ resource "null_resource" "get_github_release_artifact" {
     file_hash      = var.validation_sha
   }
   provisioner "local-exec" {
-    command = "bash ${path.module}/scripts/dl-release.sh ${local.github_dl_url} ${var.github_filename} ${var.validation_sha}"
+    command = "bash ${path.module}/scripts/dl-release.sh ${var.github_project} ${var.github_filename} ${var.github_release} ${var.validation_sha} ${var.github_token}"
   }
 }
 

--- a/scripts/dl-release.sh
+++ b/scripts/dl-release.sh
@@ -4,21 +4,41 @@ set -e -o pipefail
 
 # Setup/how to run
 usage() {
-    echo "Usage: $0 <url> <expectedfilename> <expectedSHA256>"
+    echo "Usage: $0 <url> <FILENAME> <CHECKSUM>"
     exit 1
 }
 [[ -z $1 || -z $2 || -z $3 ]] && usage
 set -u
 
-readonly url=$1
-readonly expectedfilename=$2
-readonly expectedSHA256=$3
 
-# get the file
-curl -sSLO $url/$expectedfilename
+readonly GITHUB="https://api.github.com"
 
-# check the file
-if [ $(sha256sum $expectedfilename | cut -f1 -d' ') = $expectedSHA256 ]; then
+readonly REPOSITORY_PATH="${1}"
+readonly FILENAME="${2}"
+readonly VERSION="${3}"
+readonly CHECKSUM="${4}"
+readonly TOKEN="${5}"
+
+function gh_curl() {
+  curl -H "Authorization: TOKEN ${TOKEN}" \
+       -H "Accept: application/vnd.github.v3.raw" \
+       "$@"
+}
+
+parser=". | map(select(.tag_name == \"${VERSION}\"))[0].assets | map(select(.name == \"${FILENAME}\"))[0].id"
+
+asset_id=$(gh_curl -s "${GITHUB}/repos/${REPOSITORY_PATH}/releases" | jq "${parser}")
+
+if [ "${asset_id}" = "null" ]; then
+  >&2 echo "ERROR: VERSION not found ${VERSION}"
+  exit 1
+fi
+
+wget -q --auth-no-challenge --header='Accept:application/octet-stream' \
+  "https://${TOKEN}:@api.github.com/repos/$REPOSITORY_PATH/releases/assets/${asset_id}" \
+  -O "${FILENAME}"
+
+if [ "$(sha256sum "${FILENAME}" | cut -f1 -d' ')" = "${CHECKSUM}" ]; then
     echo "The downloaded file's sha matched expected sha."
 else
     echo "Error: The downloaded file's sha did not match expected sha."

--- a/variables.tf
+++ b/variables.tf
@@ -3,6 +3,12 @@ variable "name" {
   type        = string
 }
 
+variable "github_token" {
+  description = "GitHub Token"
+  type        = string
+  sensitive   = true
+}
+
 variable "job_identifier" {
   description = "Identifier for specific instance of Lambda function"
   type        = string
@@ -30,7 +36,7 @@ variable "s3_key" {
 variable "github_project" {
   default     = ""
   type        = string
-  description = "The unique Github project to pull from. Currently, this must be public. Eg. 'trussworks/aws-iam-sleuth'"
+  description = "The unique Github project to pull from."
 }
 
 variable "github_release" {
@@ -59,7 +65,7 @@ variable "role_policy_arns_count" {
 
 variable "role_policy_arns" {
   description = "List of policy ARNs to attach to Lambda role"
-  type        = list
+  type        = list(any)
 }
 
 
@@ -78,25 +84,25 @@ variable "timeout" {
 variable "tags" {
   default     = {}
   description = "Map of tags for Lambda function"
-  type        = map
+  type        = map(any)
 }
 
 variable "env_vars" {
   default     = {}
   description = "Map of environment variables for Lambda function"
-  type        = map
+  type        = map(any)
 }
 
 variable "subnet_ids" {
   default     = []
   description = "List of subnet IDs for Lambda VPC config (leave empty if no VPC)"
-  type        = list
+  type        = list(any)
 }
 
 variable "security_group_ids" {
   default     = []
   description = "List of security group IDs for Lambda VPC config (leave empty if no VPC)"
-  type        = list
+  type        = list(any)
 }
 
 variable "cloudwatch_logs_retention_days" {
@@ -108,13 +114,13 @@ variable "cloudwatch_logs_retention_days" {
 variable "source_types" {
   default     = []
   description = "List of sources for Lambda triggers; order must match source_arns"
-  type        = list
+  type        = list(any)
 }
 
 variable "source_arns" {
   default     = []
   description = "List of arns for Lambda triggers; order must match source_types"
-  type        = list
+  type        = list(any)
 }
 
 variable "handler" {


### PR DESCRIPTION
This PR:
- adds authentication support for GitHub private repositories,
- introduces new system requirement: `jq`,
- updates `README.md` using latest `terraform-docs`,
- adds `MD033` into `.markdownlintrc` exclude list to satisfy pre-commit.

Note: due to `sensitive = true`, output from `local-exec` provisioner will be suppressed.